### PR TITLE
Create the geom filter [ch6501]

### DIFF
--- a/models/mapsmodel.js
+++ b/models/mapsmodel.js
@@ -63,6 +63,7 @@ class MapsModel extends PGSQLModel {
       let qb = new QueryBuilder(opts);
       let bbox = qb.bbox();
       let filter = qb.filter();
+      let the_geom = qb.the_geom();
 
       let schema = vars.dbschema;
       let table = vars.table_name;
@@ -73,7 +74,7 @@ class MapsModel extends PGSQLModel {
           FROM (
             SELECT ${ columns.join(', ') }
               FROM ${ schema }.${ table }_lastdata
-              WHERE TRUE ${ bbox } ${ filter }
+              WHERE TRUE ${ bbox } ${ the_geom } ${ filter }
           ) ld`;
 
       for (let i = 0; i < aggVars.length; i++) {

--- a/models/variablesmodel.js
+++ b/models/variablesmodel.js
@@ -951,7 +951,7 @@ VariablesModel.prototype.rankingNow = function(opts) {
 
     .then(function(data) {
       var qb = new QueryBuilder(opts);
-      var filter = `${qb.bbox()} ${qb.filter()}`;
+      var filter = `${qb.bbox()} ${qb.the_geom()} ${qb.filter()}`;
 
       var varIds = data.vars_ids;
       var varNames = data.vars;

--- a/protools/querybuilder.js
+++ b/protools/querybuilder.js
@@ -208,13 +208,53 @@ QueryBuilder.prototype.bbox = function() {
   return ret;
 }
 
-
 QueryBuilder.prototype.CARTObbox = function() {
   var ret = '';
   if ('filters' in this.opts && this.opts.filters!=null) {
     if ('bbox' in this.opts.filters && this.opts.filters.bbox!=null) {
       ret += ' AND the_geom && ' + util.format('ST_MakeEnvelope(%s,4326)', this.opts.filters.bbox);
     }
+  }
+  return ret;
+}
+
+QueryBuilder.prototype.the_geom = function(srid=4326) {
+  var ret = '';
+  var geom_filter = '';
+  var sql = [];
+  if ('filters' in this.opts && this.opts.filters!=null) {
+    if ('the_geom' in this.opts.filters && this.opts.filters.the_geom!=null) {
+      var tgeom = this.opts.filters.the_geom
+      if ('&&' in tgeom && tgeom['&&'] != null && Array.isArray(tgeom['&&']) && tgeom['&&'].length === 4) {
+        geom_filter = util.format('ST_MakeEnvelope(%s,4326)', tgeom['&&']);
+        if (srid !== 4326) {
+          geom_filter = util.format('ST_Transform(%s, %s)', geom_filter, srid);
+        }
+        sql.push(util.format('position && %s', geom_filter));
+      }
+
+      if ('id' in tgeom && tgeom.id != null) {
+        sql.push(util.format('id IN (%s)', tgeom.id));
+      }
+
+      if ('ST_Intersects' in tgeom && tgeom.ST_Intersects != null) {
+        var geom = '';
+        if (typeof(tgeom.ST_Intersects) === 'string') {
+          geom = util.format('%s::geometry', tgeom.ST_Intersects);
+        } else {
+          geom = util.format('ST_GeomFromGeoJSON(%s)', tgeom.ST_Intersects);
+        }
+        geom_filter = util.format('ST_SetSRID(%s,4326)', geom);
+        if (srid !== 4326) {
+          geom_filter = util.format('ST_Transform(%s, %s)', geom_filter, srid);
+        }
+        sql.push(util.format('ST_Intersects(position,%s)', geom_filter));
+      }
+    }
+  }
+
+  if (sql.length !== 0) {
+    ret = util.format(' AND ((%s))', sql.join(') AND ('));
   }
   return ret;
 }
@@ -234,6 +274,7 @@ QueryBuilder.prototype.filter = function() {
 QueryBuilder.prototype.condition = function() {
     // Only ONE root element allowed
   this.plainSQL += this.bbox();
+  this.plainSQL += this.the_geom();
   this.plainSQL += this.filter();
   return Promise.resolve(this);
 }

--- a/routes/maps.js
+++ b/routes/maps.js
@@ -27,6 +27,7 @@ const utils = require('../utils.js');
 const log = utils.log();
 const responseValidator = utils.responseValidator;
 const timesValidator = utils.timesValidator;
+const geomValidator = utils.geomValidator;
 
 let router = express.Router();
 
@@ -69,11 +70,12 @@ let entityResponse = function(req, res, next) {
 
 router.get('/:entity', entityValidator, entityResponse);
 
-router.post('/:entity/now', entityValidator, filtersValidator,
+router.post('/:entity/now', entityValidator, filtersValidator, geomValidator,
   responseValidator, function(req, res, next) {
     req.opts = {
       filters: req.body.filters || {'condition': {}},
-      bbox: req.body.filters ? req.body.filters.bbox : undefined
+      bbox: req.body.filters ? req.body.filters.bbox : undefined,
+      the_geom: req.body.filters ? req.body.filters.the_geom : undefined
     };
 
     return next();

--- a/routes/variables.js
+++ b/routes/variables.js
@@ -28,6 +28,7 @@ var log = utils.log();
 var VariablesModel = require('../models/variablesmodel');
 var auth = require('../auth.js');
 var responseValidator = utils.responseValidator;
+const geomValidator = utils.geomValidator;
 var CSVFormatter = require('../protools/csvformatter');
 var timesValidator = utils.timesValidator;
 
@@ -45,7 +46,7 @@ var rankingValidator = function(req, res, next) {
 /*
  * It returns the current values of the requested variables ranked by a variable.
  */
-router.post('/ranking/now', rankingValidator, responseValidator, auth.validateVariables('vars'), function(req, res, next) {
+router.post('/ranking/now', rankingValidator, geomValidator, responseValidator, auth.validateVariables('vars'), function(req, res, next) {
   var opts = {
     scope: req.scope,
     filters: req.body.filters || {},
@@ -346,6 +347,7 @@ var histogramDiscreteNowValidator = function(req, res, next) {
 // HISTOGRAMS
 router.post('/:id/histogram/discrete/now',
   histogramDiscreteNowValidator,
+  geomValidator,
   responseValidator,
   auth.validateVariables('id'),
   function(req, res, next) {

--- a/utils.js
+++ b/utils.js
@@ -76,4 +76,11 @@ module.exports.responseValidator = function(req, res, next){
 
     });
   }
-}
+};
+
+module.exports.geomValidator = function(req, res, next) {
+  req.checkBody('filters.the_geom["&&"]', 'Must be an array with 4 values').optional().isArray();
+  req.checkBody('filters.the_geom.ST_Intersects', 'Must be a string or GeoJSON').optional().notEmpty();
+  req.checkBody('filters.the_geom.id', 'Must be a valid id').optional().notEmpty();
+  return next();
+};


### PR DESCRIPTION
Allow API users to apply filters with *the_geom* filter. This filter is aimed to deprecate the current bbox filter. At this moment this filter can be used in the following endpoints:
- /:scope/maps/:entity/now
- /:scope/variables/ranking/now

Filter validation must be improved in the future.