### PR TITLE
Check if variables come from getVarQueryArray or getVarQuery in querybuilder

### DIFF
--- a/protools/querybuilder.js
+++ b/protools/querybuilder.js
@@ -132,11 +132,17 @@ QueryBuilder.prototype.group = function(that) {
     } else if (typeof that.opts.ranges[0] === 'object') {
       var fullCases = [];
       var rangeCounter = 1;
+      var field;
+      if (that.opts.raw.vars)
+        field = that.opts.raw.vars[0];
+      else
+        field = that.opts.raw.entity_field;
+
       for (var range of that.opts.ranges) {
         var cases = [];
         var stringCase = 'count(CASE WHEN ';
         for (var k in range) {
-          cases.push(that.opts.raw.vars[0] + k + range[k]);
+          cases.push(field + k + range[k]);
         }
         stringCase += cases.join(' AND ');
         stringCase += ' THEN ' + rangeCounter;


### PR DESCRIPTION
The new `subRanges` feature for discrete histograms introduced a bug in the `querybuilder`'s `group()` function. This fix avoids using undefined attributes in the `opts` object when `group()` is called from other types of histograms functions.