### PR TITLE
[ch8974] Inject the current user when creating/updating a scope with DeMA activated

### DIFF
--- a/orioncb/oriondema.js
+++ b/orioncb/oriondema.js
@@ -57,14 +57,14 @@ class OrionDeMA extends OrionBaseV2 {
     super(subs);
   }
 
-  updateScopeStatus(scope, action) {
+  updateScopeStatus(scope, action, user) {
 
     if (action !== 'created' && action !== 'updated' && action !== 'deleted') return Promise.resolve();
 
     return new Promise((resolve, reject) => {
 
       let model = new MD();
-      model.getScopesWithMetadata(scope, null, (error, data) => {
+      model.getScopesWithMetadata(scope, user, (error, data) => {
         data = data[0];
         if (error) return reject(error);
 

--- a/routes/admin/scopes.js
+++ b/routes/admin/scopes.js
@@ -104,7 +104,7 @@ router.post('/',
       else {
         if (req.withDeMA) {
           let dema = new OrionDeMA(config.getDeMA(res.locals.dema_access_token));
-          dema.updateScopeStatus(data.id, 'created')
+          dema.updateScopeStatus(data.id, 'created', res.user)
           .then( d => {
             return res.status(201).json(data);
           })
@@ -144,7 +144,7 @@ router.put('/:scope',
         else {
           if (req.withDeMA) {
             let dema = new OrionDeMA(config.getDeMA(res.locals.dema_access_token));
-            dema.updateScopeStatus(req.params.scope, 'updated')
+            dema.updateScopeStatus(req.params.scope, 'updated', res.user)
             .then( d => {
               return res.sendStatus(200);
             })


### PR DESCRIPTION
When a scope was created or updated with the API configured to use DeMA the
process failed because it was missing a reference to the user who sent the
request.