### PR TITLE
Avoid references to undefined variables in querybuilder.group

### DIFF
--- a/protools/querybuilder.js
+++ b/protools/querybuilder.js
@@ -161,7 +161,10 @@ QueryBuilder.prototype.group = function(that) {
     }
   }
 
-  that.plainSQL += ' GROUP BY (' + that.opts.raw.vars[0];
+  if (that.opts.raw.vars)
+    that.plainSQL += ' GROUP BY (' + that.opts.raw.vars[0];
+  else
+    that.plainSQL += ' GROUP BY (' + that.opts.raw.entity_field;
 
   if (groupBySub) {
     that.plainSQL += groupBySub;


### PR DESCRIPTION
When updating the group function in order to support ranges and sub-ranges a bug was introduced. If "all" was specified in a request to any of the histogram endpoints the request could fail. 